### PR TITLE
Dry run

### DIFF
--- a/dcsg.go
+++ b/dcsg.go
@@ -10,7 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newDscg(dockerComposeFile, projectName string) (*dcsg, error) {
+func newDscg(dockerComposeFile, projectName string, dryRun bool) (*dcsg, error) {
 
 	cleanedFilePath, err := filepath.Abs(dockerComposeFile)
 	if err != nil {
@@ -38,15 +38,15 @@ func newDscg(dockerComposeFile, projectName string) (*dcsg, error) {
 	dockerComposeFileName := filepath.Base(dockerComposeFile)
 
 	systemdDirectory := "/etc/systemd/system"
-	commandExecutor := newExecutor(os.Stdin, os.Stdout, os.Stderr, "")
+	commandExecutor := newExecutor(os.Stdin, os.Stdout, os.Stderr, "", dryRun)
 
 	return &dcsg{
 		projectDirectory:      projectDirectory,
 		dockerComposeFileName: dockerComposeFileName,
 		projectName:           projectName,
 
-		installer:   &systemdInstaller{systemdDirectory, commandExecutor},
-		uninstaller: &systemdUninstaller{systemdDirectory, commandExecutor},
+		installer:   &systemdInstaller{systemdDirectory, commandExecutor, dryRun},
+		uninstaller: &systemdUninstaller{systemdDirectory, commandExecutor, dryRun},
 	}, nil
 }
 

--- a/installer_test.go
+++ b/installer_test.go
@@ -7,8 +7,14 @@ import (
 	"testing"
 )
 
-func Test_createSystemdService_NoErrorIsReturned(t *testing.T) {
+func getTestInstaller() *systemdInstaller {
 	targetDirectory := os.TempDir()
+	commandExecutor := newExecutor(os.Stdin, os.Stdout, os.Stderr, "", false)
+	return &systemdInstaller{targetDirectory, commandExecutor, false}
+}
+
+func Test_createSystemdService_NoErrorIsReturned(t *testing.T) {
+	installer := getTestInstaller()
 
 	serviceViewModel := serviceDefinition{
 		ProjectName:       "exampleproject",
@@ -16,7 +22,7 @@ func Test_createSystemdService_NoErrorIsReturned(t *testing.T) {
 		DockerComposeFile: "docker-compose.yml",
 	}
 
-	result := createSystemdService(serviceViewModel, targetDirectory)
+	result := installer.createSystemdService(serviceViewModel)
 
 	if result != nil {
 		t.Fail()
@@ -25,7 +31,7 @@ func Test_createSystemdService_NoErrorIsReturned(t *testing.T) {
 }
 
 func Test_createSystemdService_ServiceFileIsWritten(t *testing.T) {
-	targetDirectory := os.TempDir()
+	installer := getTestInstaller()
 
 	serviceViewModel := serviceDefinition{
 		ProjectName:       "exampleproject",
@@ -33,14 +39,14 @@ func Test_createSystemdService_ServiceFileIsWritten(t *testing.T) {
 		DockerComposeFile: "docker-compose.yml",
 	}
 
-	result := createSystemdService(serviceViewModel, targetDirectory)
+	result := installer.createSystemdService(serviceViewModel)
 
 	if result != nil {
 		t.Fail()
 		t.Logf("createSystemdService returned %s", result)
 	}
 
-	targetFilePath := filepath.Join(targetDirectory, fmt.Sprintf("%s.service", serviceViewModel.ProjectName))
+	targetFilePath := filepath.Join(installer.systemdDirectory, fmt.Sprintf("%s.service", serviceViewModel.ProjectName))
 	_, err := os.Stat(targetFilePath)
 	if err != nil {
 		t.Fail()

--- a/main.go
+++ b/main.go
@@ -11,7 +11,8 @@ const applicationName = "dcsg"
 const applicationVersion = "v0.4.0"
 
 var (
-	app = kingpin.New(applicationName, fmt.Sprintf("%s creates systemd services for Docker Compose projects (%s)", applicationName, applicationVersion))
+	app       = kingpin.New(applicationName, fmt.Sprintf("%s creates systemd services for Docker Compose projects (%s)", applicationName, applicationVersion))
+	appDryRun = app.Flag("dry-run", "Print details of what would be done but do not install anything").Short('n').Bool()
 
 	// install
 	installCommand           = app.Command("install", "Register a systemd service for the given docker-compose file")
@@ -38,7 +39,7 @@ func handleCommandlineArgument(arguments []string) {
 	switch kingpin.MustParse(app.Parse(arguments)) {
 
 	case installCommand.FullCommand():
-		service, err := newDscg(*installDockerComposeFile, *installProjectName)
+		service, err := newDscg(*installDockerComposeFile, *installProjectName, *appDryRun)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
@@ -50,7 +51,7 @@ func handleCommandlineArgument(arguments []string) {
 		}
 
 	case uninstallCommand.FullCommand():
-		service, err := newDscg(*uninstallDockerComposeFile, *uinstallProjectName)
+		service, err := newDscg(*uninstallDockerComposeFile, *uinstallProjectName, *appDryRun)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)


### PR DESCRIPTION
I had a go at fixing https://github.com/andreaskoch/dcsg/issues/9 by adding a dry-run mode to the command. This shows all of the changes that would be made but does not actually install any files or run any commands.

Some example output:

```console
$ ~/dev/git/dcsg/bin/dcsg -n install
2018/08/07 17:54:25 Installing this service file at: /etc/systemd/system/jenkins.service
[Unit]
Description=jenkins Service
After=network.service docker.service
Requires=docker.service

[Service]
Restart=always
RestartSec=10
TimeoutSec=300
WorkingDirectory=/home/joelnb/dev/docker-compose/jenkins
ExecStartPre=/usr/bin/env docker-compose -p "jenkins" -f "docker-compose.yml" pull
ExecStart=/usr/bin/env docker-compose -p "jenkins" -f "docker-compose.yml" up
ExecStop=/usr/bin/env docker-compose -p "jenkins" -f "docker-compose.yml" stop
ExecStopPost=/usr/bin/env docker-compose -p "jenkins" -f "docker-compose.yml" down

[Install]
WantedBy=docker.service
2018/08/07 17:54:25 : systemctl daemon-reload
2018/08/07 17:54:25 : systemctl enable jenkins.service
2018/08/07 17:54:25 : systemctl start jenkins.service
```

And for an uninstall:

```console
$ ~/dev/git/dcsg/bin/dcsg -n uninstall
2018/08/07 17:54:35 : systemctl stop jenkins.service
2018/08/07 17:54:35 : systemctl disable jenkins.service
2018/08/07 17:54:35 Would remove file: /etc/systemd/system/jenkins.service
2018/08/07 17:54:35 : systemctl daemon-reload
```