### PR TITLE
Correct links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin
 .DS_Store
+
+/dcsg

--- a/README.md
+++ b/README.md
@@ -63,13 +63,13 @@ For the `uninstall` action **dcsg** remove the systemd service it created earlie
 
 You can download pre-built binaries for Linux (64bit, ARM 5, ARM 6 and ARM 7) from [github.com » andreaskoch » dcsg » releases](/releases/latest):
 
-- [Download for dcsg (Linux 64bit)](https://github.com/andreaskoch/dcsg/releases/download/v0.3.0/dcsg_linux_amd64)
-- [Download for dcsg (Linux ARM5)](https://github.com/andreaskoch/dcsg/releases/download/v0.3.0/dcsg_linux_arm5)
-- [Download for dcsg (Linux ARM6)](https://github.com/andreaskoch/dcsg/releases/download/v0.3.0/dcsg_linux_arm6)
-- [Download for dcsg (Linux ARM7)](https://github.com/andreaskoch/dcsg/releases/download/v0.3.0/dcsg_linux_arm7)
+- [Download for dcsg (Linux 64bit)](https://github.com/andreaskoch/dcsg/releases/download/v0.4.0/dcsg_linux_amd64)
+- [Download for dcsg (Linux ARM5)](https://github.com/andreaskoch/dcsg/releases/download/v0.4.0/dcsg_linux_arm5)
+- [Download for dcsg (Linux ARM6)](https://github.com/andreaskoch/dcsg/releases/download/v0.4.0/dcsg_linux_arm6)
+- [Download for dcsg (Linux ARM7)](https://github.com/andreaskoch/dcsg/releases/download/v0.4.0/dcsg_linux_arm7)
 
 ```bash
-curl -L https://github.com/andreaskoch/dcsg/releases/download/v0.3.0/dcsg_linux_amd64 > /usr/local/bin/dcsg
+curl -L https://github.com/andreaskoch/dcsg/releases/download/v0.4.0/dcsg_linux_amd64 > /usr/local/bin/dcsg
 chmod +x /usr/local/bin/dcsg
 ```
 


### PR DESCRIPTION
Correct the links in the README to point to the latest version from the releases page.

I also added the default binary generated with `go build` to the `.gitignore` so that it will be ignored even if someone builds not using the Makefile.