### PR TITLE
Add support for omitting the pull step

### DIFF
--- a/dcsg.go
+++ b/dcsg.go
@@ -10,8 +10,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func newDscg(dockerComposeFile, projectName string, dryRun bool) (*dcsg, error) {
-
+func newDscg(dockerComposeFile, projectName string, dryRun bool, doPull bool) (*dcsg, error) {
 	cleanedFilePath, err := filepath.Abs(dockerComposeFile)
 	if err != nil {
 		return nil, err
@@ -45,7 +44,7 @@ func newDscg(dockerComposeFile, projectName string, dryRun bool) (*dcsg, error) 
 		dockerComposeFileName: dockerComposeFileName,
 		projectName:           projectName,
 
-		installer:   &systemdInstaller{systemdDirectory, commandExecutor, dryRun},
+		installer:   &systemdInstaller{systemdDirectory, commandExecutor, dryRun, doPull},
 		uninstaller: &systemdUninstaller{systemdDirectory, commandExecutor, dryRun},
 	}, nil
 }

--- a/installer.go
+++ b/installer.go
@@ -18,6 +18,7 @@ type systemdInstaller struct {
 	systemdDirectory string
 	commandExecutor  Executor
 	dryRun           bool
+	doPull           bool
 }
 
 func (installer *systemdInstaller) Install(projectDirectory, dockerComposeFileName, projectName string) error {
@@ -27,6 +28,7 @@ func (installer *systemdInstaller) Install(projectDirectory, dockerComposeFileNa
 		ProjectName:       projectName,
 		ProjectDirectory:  projectDirectory,
 		DockerComposeFile: dockerComposeFileName,
+		DoPull:            installer.doPull,
 	}
 
 	if err := installer.createSystemdService(serviceViewModel); err != nil {
@@ -92,7 +94,9 @@ Restart=always
 RestartSec=10
 TimeoutSec=300
 WorkingDirectory={{ .ProjectDirectory }}
+{{- if .DoPull }}
 ExecStartPre=/usr/bin/env docker-compose -p "{{ .ProjectName }}" -f "{{ .DockerComposeFile }}" pull
+{{- end }}
 ExecStart=/usr/bin/env docker-compose -p "{{ .ProjectName }}" -f "{{ .DockerComposeFile }}" up
 ExecStop=/usr/bin/env docker-compose -p "{{ .ProjectName }}" -f "{{ .DockerComposeFile }}" stop
 ExecStopPost=/usr/bin/env docker-compose -p "{{ .ProjectName }}" -f "{{ .DockerComposeFile }}" down
@@ -105,4 +109,5 @@ type serviceDefinition struct {
 	ProjectName       string
 	ProjectDirectory  string
 	DockerComposeFile string
+	DoPull            bool
 }

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
 	installCommand           = app.Command("install", "Register a systemd service for the given docker-compose file")
 	installDockerComposeFile = installCommand.Arg("docker-compose-file", "A docker-compose file").Default("docker-compose.yml").String()
 	installProjectName       = installCommand.Arg("project-name", "The project name of the docker-compose project").String()
+	installDontPull          = installCommand.Flag("no-pull", "The project name of the docker-compose project").Bool()
 
 	// uninstall
 	uninstallCommand           = app.Command("uninstall", "Uninstall the systemd service for the given docker-compose file")
@@ -35,11 +36,10 @@ func main() {
 }
 
 func handleCommandlineArgument(arguments []string) {
-
 	switch kingpin.MustParse(app.Parse(arguments)) {
 
 	case installCommand.FullCommand():
-		service, err := newDscg(*installDockerComposeFile, *installProjectName, *appDryRun)
+		service, err := newDscg(*installDockerComposeFile, *installProjectName, *appDryRun, !(*installDontPull))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
@@ -51,7 +51,7 @@ func handleCommandlineArgument(arguments []string) {
 		}
 
 	case uninstallCommand.FullCommand():
-		service, err := newDscg(*uninstallDockerComposeFile, *uinstallProjectName, *appDryRun)
+		service, err := newDscg(*uninstallDockerComposeFile, *uinstallProjectName, *appDryRun, !(*installDontPull))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
@@ -61,7 +61,5 @@ func handleCommandlineArgument(arguments []string) {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
-
 	}
-
 }


### PR DESCRIPTION
By passing the flag --no-pull to the install command it is now possible
to omit the pull step from the generated systemd service file. This
allows using local images which are updated by some external process.

This is an attempt to address https://github.com/andreaskoch/dcsg/issues/7